### PR TITLE
Continuous zoom and optimized render approach

### DIFF
--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -350,9 +350,6 @@ class GraphicsView(NSView):
         viewToCanvas.scaleBy_(1.0/self.zoom)
         canvasRect = viewToCanvas.transformRect_(rect)
         
-        print(f"Dirty rect (view coords): origin({rect.origin.x:.1f}, {rect.origin.y:.1f}), size({rect.size.width:.1f}, {rect.size.height:.1f})")
-        print(f"Canvas rect (unzoomed): origin({canvasRect.origin.x:.1f}, {canvasRect.origin.y:.1f}), size({canvasRect.size.width:.1f}, {canvasRect.size.height:.1f})")
-        
         # Set up the graphics state for zoomed drawing
         NSGraphicsContext.currentContext().saveGraphicsState()
         
@@ -364,10 +361,6 @@ class GraphicsView(NSView):
         # Set up clipping to the intersection of canvas bounds and visible area
         canvasBounds = ((0, 0), self.canvas.pagesize)
         visibleBounds = NSIntersectionRect(canvasRect, canvasBounds)
-        print(f"Clipped bounds: origin({visibleBounds.origin.x:.1f}, {visibleBounds.origin.y:.1f}), size({visibleBounds.size.width:.1f}, {visibleBounds.size.height:.1f})")
-        print(f"Canvas size: {self.canvas.pagesize}")
-        print("---")
-        
         clip = NSBezierPath.bezierPathWithRect_(visibleBounds)
         clip.addClip()
         

--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -11,8 +11,6 @@ from ..gfx import Color
 from ..gfx.atoms import KEY_ESC
 from objc import super
 
-DARK_GREY = NSColor.blackColor().blendedColorWithFraction_ofColor_(0.7, NSColor.whiteColor())
-
 class GraphicsBackdrop(NSView):
     """A container that sits between the NSClipView and GraphicsView
 


### PR DESCRIPTION
---
Continuous zoom
---

- Added pinch-to-zoom gesture support
- Added Command+scroll for zooming

https://github.com/user-attachments/assets/73c51466-18f0-4461-bee8-3893bb4bfa18

---
Optimized render approach
---

Previously, the GraphicsView would pre-render the entire canvas to a bitmap (NSImage) at the current zoom level, convert it to a CALayer's contents, and display that layer. This has been replaced with direct drawing to the view's graphics context, using viewport clipping to only draw the visible portion of the canvas.

Changes:
- Removed layer-based rendering approach (CALayer and bitmap caching)
- Added drawRect_ method to draw canvas contents directly to view's graphics context
- Implemented viewport clipping
- Canvas contents are now scaled using NSAffineTransform instead of pre-scaling bitmaps
- Removed unused backing scale factor (_dpr) and related bitmap rendering code

<img width="1212" alt="render_comparison" src="https://github.com/user-attachments/assets/013862c7-84d5-400d-981b-c78889b16983" />

### Performance characteristics:
**Previous (Cached) Approach**
\+ Fast scrolling when zoomed in (just moving a pre-rendered bitmap)
\+ Consistent performance regardless of canvas complexity
\- Drawing large images at high zoom levels
\- Initial render and zooming could be slow

**New (Direct Drawing) Approach**
\+ Faster initial render (good for animations)
\+ Lower memory usage
\+ Clips rendering to visible area when zoomed in
\+ More responsive zooming
\- Have to redraw during scrolling so worse performance there
\- Performance depends on complexity of visible canvas area

This is particularly helpful when working with animations, since each frame draws faster:

https://github.com/user-attachments/assets/c2d587ec-b014-40cb-88e5-a89e318bdde0



