### PR TITLE
Build and dependency updates

### DIFF
--- a/deps/frameworks/Makefile
+++ b/deps/frameworks/Makefile
@@ -3,11 +3,14 @@ FRAMEWORK_REPO = https://github.com/gregneagle/relocatable-python.git
 BUILD_OPTS = --os-version=11 --python-version=$(PYTHON_VERSION) --upgrade-pip --pip-requirements=requirements.txt
 BIN = ./Python.framework/Versions/Current/bin
 
+# Use PIP_NO_CACHE_DIR from environment if set, otherwise empty
+PIP_ENV = $(if $(PIP_NO_CACHE_DIR),PIP_NO_CACHE_DIR=1,)
+
 all: Python.framework
-	$(BIN)/pip3 install --upgrade ../..
+	$(PIP_ENV) $(BIN)/pip3 install --upgrade ../..
 
 Python.framework: relocatable-python
-	PYTHONNOUSERSITE=1 python3 ./relocatable-python/make_relocatable_python_framework.py $(BUILD_OPTS)
+	PYTHONNOUSERSITE=1 $(PIP_ENV) python3 ./relocatable-python/make_relocatable_python_framework.py $(BUILD_OPTS)
 	$(BIN)/python3 config.py ../../app/python.xcconfig
 
 relocatable-python:

--- a/deps/frameworks/Makefile
+++ b/deps/frameworks/Makefile
@@ -7,7 +7,7 @@ all: Python.framework
 	$(BIN)/pip3 install --upgrade ../..
 
 Python.framework: relocatable-python
-	python3 ./relocatable-python/make_relocatable_python_framework.py $(BUILD_OPTS)
+	PYTHONNOUSERSITE=1 python3 ./relocatable-python/make_relocatable_python_framework.py $(BUILD_OPTS)
 	$(BIN)/python3 config.py ../../app/python.xcconfig
 
 relocatable-python:

--- a/deps/frameworks/requirements.txt
+++ b/deps/frameworks/requirements.txt
@@ -1,5 +1,6 @@
 # --no-binary :all:
 xattr
+filelock
 cachecontrol
 cffi
 lockfile

--- a/setup.py
+++ b/setup.py
@@ -338,14 +338,20 @@ class TestCommand(Command):
 
 class BuildAppCommand(Command):
     description = "Build PlotDevice.app with xcode"
-    user_options = []
+    user_options = [
+        ('no-cache', None, 'do not use pip cache when installing dependencies'),
+    ]
+    
     def initialize_options(self):
-        pass
+        self.no_cache = None
 
     def finalize_options(self):
         # make sure the embedded framework exists (and has updated app/python.xcconfig)
         print("Set up Python.framework for app build")
-        call('cd deps/frameworks && make', shell=True)
+        env = os.environ.copy()
+        if self.no_cache:
+            env['PIP_NO_CACHE_DIR'] = '1'
+        call('cd deps/frameworks && make', shell=True, env=env)
 
     def run(self):
         self.spawn(['xcodebuild', '-configuration', 'Release'])

--- a/setup.py
+++ b/setup.py
@@ -182,33 +182,63 @@ def stale(dst, src):
 ## Build Commands ##
 
 class CleanCommand(Command):
-    description = "wipe out the ./build & ./dist dirs and other setup-generated files"
-    user_options = []
-    def initialize_options(self):
-        pass
-    def finalize_options(self):
-        pass
-    def run(self):
-        os.system('rm -rf ./build ./dist')
-        os.system('rm -rf plotdevice.egg-info MANIFEST.in PKG')
-        os.system('rm -rf ./tests/_out ./tests/_diff ./details.html')
-        os.system('rm -f ./_plotdevice.*.so')
-        os.system('cd deps/extensions/svg && make clean')
-        os.system('find plotdevice -name .DS_Store -exec rm {} \;')
-        os.system('find plotdevice -name \*.pyc -exec rm {} \;')
-        os.system('find plotdevice -name __pycache__ -type d -prune -exec rmdir {} \;')
+    description = "wipe out generated files and build artifacts"
+    user_options = [
+        ('dist', None, 'also remove Python.framework and local dependencies'),
+    ]
 
-class DistCleanCommand(Command):
-    description = "delete Python.framework, local pypi dependencies, and all generated files"
-    user_options = []
     def initialize_options(self):
-        pass
+        self.dist = None
+
     def finalize_options(self):
         pass
+
     def run(self):
-        self.run_command('clean')
-        os.system('rm -rf ./deps/local')
-        os.system('rm -rf ./deps/frameworks/*.framework')
+        paths = [
+            'build',
+            'dist',
+            '*.egg',
+            '*.egg-info',
+            '.eggs',
+            'MANIFEST.in',
+            'PKG',
+            'tests/_out',
+            'tests/_diff',
+            'details.html',
+            '_plotdevice.*.so',
+            '**/*.pyc',
+            '**/__pycache__',
+            '**/.DS_Store',
+        ]
+
+        # Add framework paths if --dist flag is used
+        if self.dist:
+            paths.extend([
+                'deps/local',
+                'deps/frameworks/Python.framework',
+                'deps/frameworks/relocatable-python',
+            ])
+
+        for path_pattern in paths:
+            for path in glob(path_pattern, recursive=True):
+                if exists(path):
+                    print('removing %s'%path)
+                    if os.path.isdir(path):
+                        rmtree(path)
+                    else:
+                        os.unlink(path)
+                        
+        # Run make clean in svg extensions dir
+        if exists('deps/extensions/svg'):
+            os.system('cd deps/extensions/svg && make clean')
+
+class DistCleanCommand(CleanCommand):
+    """Alias for `clean --dist` for backward compatibility"""
+    description = "delete Python.framework, local pypi dependencies, and all generated files"
+    
+    def initialize_options(self):
+        super().initialize_options()
+        self.dist = True  # always do a deep clean
 
 class LocalDevCommand(Command):
     description = "set up environment to allow for running `python -m plotdevice` within the repo"


### PR DESCRIPTION
This PR makes some small changes to the build process and dependencies:

1. More comprehensive clean command

- clean command now catches additional files
- uses Python's file ops instead of shell commands
- clean has --dist option to clean the python distribution
- DistCleanCommand now inherits from CleanCommand

2. Added no-cache build option (helpful when you want to force fresh package downloads)

- new --no-cache flag for python setup.py app
- makefile can now optionally use PIP_NO_CACHE_DIR

3. Added filelock to package dependencies (needed for CacheControl FileCache)

4. Lazy initialisation for URL handling in readers.py

- this was causing build failures since dependencies weren't yet loaded
- only imports and sets up HTTP functionality when it's actually needed
- provides an error message if dependencies are missing
- allows the rest of plotdevice to work even if HTTP functionality isn't available

I've tested:

- building app now works (wasn't working for me previously)
- clean commands remove additional stuff
- no-cache flag works as expected
- URL loading in read() works properly